### PR TITLE
[Bug]: Typo in Domains.rst

### DIFF
--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -850,7 +850,7 @@ Note however that no checking is performed with respect to parameter
 compatibility. E.g., ``Iterator{A, B, C}`` will be accepted as an introduction
 even though it would not be valid C++.
 
-Inline Expressions and Tpes
+Inline Expressions and Types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. rst:role:: cpp:expr


### PR DESCRIPTION
Subject: Fix Typo

### Feature or Bugfix
- Bugfix

### Purpose
- Fix typo

### Detail
- Types misspelled in documentation

### Relates
- NONE